### PR TITLE
Configure SwiftLint rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -36,7 +36,50 @@ opt_in_rules:
   - force_unwrapping
   - identical_operands
   - implicit_return
-
+  - implicitly_unwrapped_optional
+  - indentation_width
+  - joined_default_parameter
+  - last_where
+  - legacy_objc_type
+  - legacy_random
+  - literal_expression_end_indentation
+  - modifier_order
+  - multiline_arguments
+  - multiline_literal_brackets
+  - multiline_parameters
+  - multiline_parameters_brackets
+  - multiline_function_chains
+  - number_separator
+  - operator_usage_whitespace
+  - optional_enum_case_matching
+  - overridden_super_call
+  - override_in_extension
+  - pattern_matching_keywords
+  - prefer_self_type_over_type_of_self
+  - prefer_zero_over_explicit_init
+  - prohibited_interface_builder
+  - prohibited_super_call
+  - raw_value_for_camel_cased_codable_enum
+  - reduce_into
+  - single_test_class
+  - sorted_first_last
+  - sorted_imports
+  - static_operator
+#  - strict_fileprivate
+  - test_case_accessibility
+  - toggle_bool
+  - type_contents_order
+  - unavailable_function
+  - unneeded_parentheses_in_closure_argument
+  - unused_import
+  - unused_declaration
+  - vertical_parameter_alignment_on_call
+  - vertical_whitespace_closing_braces
+  - vertical_whitespace_opening_braces
+  - weak_delegate
+  - xct_specific_matcher
+  - yoda_condition
+  
 large_tuple:
   - 5 # warning
   - 5 # error

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -43,8 +43,12 @@ opt_in_rules:
   - legacy_objc_type
   - legacy_random
   - literal_expression_end_indentation
+  - lower_acl_than_parent
+  # This should be opted in once we're in a shape where we can accept open source contributions
+  # - missing_docs
   - modifier_order
   - multiline_arguments
+  - multiline_arguments_brackets
   - multiline_literal_brackets
   - multiline_parameters
   - multiline_parameters_brackets
@@ -57,20 +61,26 @@ opt_in_rules:
   - pattern_matching_keywords
   - prefer_self_type_over_type_of_self
   - prefer_zero_over_explicit_init
+  - prefixed_toplevel_constant
+  - private_subject
   - prohibited_interface_builder
   - prohibited_super_call
   - raw_value_for_camel_cased_codable_enum
   - reduce_into
+  - redundant_nil_coalescing
   - single_test_class
   - sorted_first_last
   - sorted_imports
   - static_operator
-#  - strict_fileprivate
+  - switch_case_on_newline
   - test_case_accessibility
   - toggle_bool
+  - trailing_closure
   - type_contents_order
   - unavailable_function
   - unneeded_parentheses_in_closure_argument
+  - untyped_error_in_catch
+  - unowned_variable_capture 
   - unused_import
   - unused_declaration
   - vertical_parameter_alignment_on_call

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,3 +4,49 @@ analyzer_rules:
   - unused_declaration
   - unused_import
 opt_in_rules:
+  - anonymous_argument_in_multiline_closure
+  - anyobject_protocol
+  - array_init
+  - balanced_xctest_lifecycle
+  - capture_variable
+  - closure_end_indentation
+  - closure_spacing
+  - collection_alignment
+  - contains_over_filter_count
+  - contains_over_filter_is_empty
+  - contains_over_first_not_nil
+  - contains_over_range_nil_comparison
+  - convenience_type
+  - discouraged_assert
+  - discouraged_none_name
+  - discouraged_object_literal
+  - discouraged_optional_boolean
+  - discouraged_optional_collection
+  - empty_collection_literal
+  - empty_count
+  - empty_string
+  - empty_xctest_method
+  - enum_case_associated_values_count
+  - extension_access_modifier
+  - fatal_error_message
+  - file_name_no_space
+  - file_types_order
+  - first_where
+  - flatmap_over_map_reduce
+  - force_unwrapping
+  - identical_operands
+  - implicit_return
+
+large_tuple:
+  - 5 # warning
+  - 5 # error
+enum_case_associated_values_count:
+  - 5 # warning
+  - 5 # error
+line_length:
+  - 120 # warning
+  - 120 # error
+nesting:
+  type_level:
+    warning: 2
+    error: 2

--- a/Log/Shared/ContentView.swift
+++ b/Log/Shared/ContentView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct ContentView: View {
+        let   x  = "String"
     var body: some View {
         Text("Hello, world!")
             .padding()

--- a/Log/Shared/ContentView.swift
+++ b/Log/Shared/ContentView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ContentView: View {
-        let   x  = "String"
+    let x = "String"
     var body: some View {
         Text("Hello, world!")
             .padding()


### PR DESCRIPTION
## Didn't opted in:

https://realm.github.io/SwiftLint/legacy_multiple.html
legacy_multiple --> En ezt hasznalom

https://realm.github.io/SwiftLint/let_var_whitespace.html
let_var_whitespace --> Ha pl valami lokalis valtozonak if-else-ben adok erteket, akkor azt en kozvetlen az if ele irom, hogy latszodjon hogy ossze tartoznak

https://realm.github.io/SwiftLint/lower_acl_than_parent.html
lower_acl_than_parent --> Ez nem default Xcode-ban?

https://realm.github.io/SwiftLint/missing_docs.html
missing_docs --> Lehet nem lenne rossz ha open sourceolni akarjuk, es engedni akarjuk h masik implementaljanak beepulo modulokat

https://realm.github.io/SwiftLint/nimble_operator.html
nimble_operator --> Ezt csak Nimble-re van? Nem ertem tejlesen

https://realm.github.io/SwiftLint/multiline_arguments_brackets.html
multiline_arguments_brackets --> Ez SwiftUI-nal nem biztos h tul kenyelmes lesz

https://realm.github.io/SwiftLint/no_extension_access_modifier.html
no_extension_access_modifier --> Szerintem nem rossz ha mondjuk csak private dolgok vannak egy extensionben akkor nem kell mind ele kitenni

https://realm.github.io/SwiftLint/no_grouping_extension.html
no_grouping_extension --> Ezt nem igazan tudom eldonteni

https://realm.github.io/SwiftLint/nslocalizedstring_key.html
nslocalizedstring_key --> Szerintem ezeket a stringeket generalni kene h legyen compile time check, szoval mindegy ez a rule

https://realm.github.io/SwiftLint/nslocalizedstring_require_bundle.html
nslocalizedstring_require_bundle --> u.a. mint elobb

https://realm.github.io/SwiftLint/object_literal.html
object_literal --> Asszem bekapcsoltuk ennek az ellenkezojet

https://realm.github.io/SwiftLint/prefer_nimble.html
prefer_nimble --> Valszeg csak en vagyok maradi, de en meg mindig ezeket az XCTAssert dolgokat hasznalom, errol az expect-rol nem is hallottam

https://realm.github.io/SwiftLint/prefer_self_in_static_references.html
prefer_self_in_static_references --> Nincs preferenciam, nekem mindegy, bekapcsolhatjuk ha gondolod

https://realm.github.io/SwiftLint/prefixed_toplevel_constant.html
prefixed_toplevel_constant --> Bizom benne h nem is lesz top level konstansunk, vagy max fileprivate. Ott meg nekem mindegy

private_action, private_outlet --> IBAction, IBOutlet, remelem egyiket se fogjuk hasznalni :D (be is tettem hogy prohibited_interface_builder)

https://realm.github.io/SwiftLint/private_subject.html
private_subject --> En ezzel nem ertek egyet, mi van ha inputnak hasznaljuk?

https://realm.github.io/SwiftLint/quick_discouraged_call.html
quick_discouraged_call --> Ez Quick/Nimble specifikus

https://realm.github.io/SwiftLint/quick_discouraged_focused_test.html
quick_discouraged_focused_test --> Ez Quick/Nimble specifikus

https://realm.github.io/SwiftLint/quick_discouraged_pending_test.html
quick_discouraged_pending_test --> Ez Quick/Nimble specifikus

https://realm.github.io/SwiftLint/redundant_nil_coalescing.html
redundant_nil_coalescing --> Nem teljesen ertem, ez csak akkor mukodik ha egy sorban vannak irva a dolgok? :D 

https://realm.github.io/SwiftLint/redundant_type_annotation.html
redundant_type_annotation --> Lehet h jo otlet, bar ha kiirjuk fixen a type-ot az gyorsitja a forditast. En sem szoktam mondjuk...

https://realm.github.io/SwiftLint/required_deinit.html
required_deinit --> Sztem erre nagyon nagyon ritkan van tenyleg szukseg

https://realm.github.io/SwiftLint/required_enum_case.html
required_enum_case --> Nem igazan ertem.

https://realm.github.io/SwiftLint/strict_fileprivate.html
strict_fileprivate --> Nem surun de en szoktam hasnzalni fileprivate-ot, majd lecsekkolom, hogy pontosan mi is a use case

https://realm.github.io/SwiftLint/strong_iboutlet.html
strong_iboutlet --> Nem hasnzalunk IB-t

https://realm.github.io/SwiftLint/switch_case_on_newline.html
switch_case_on_newline --> En szoktam egy sorba irni az utasitast a case-zel amennyiben az nem tul hosszu es konnyen atlathato.

https://realm.github.io/SwiftLint/trailing_closure.html
trailing_closure --> Ezt nem tudom eldonteni, van hogy kiirom a closure parameter nevet, ha nem teljesen egyertelmu h az micsoda.

https://realm.github.io/SwiftLint/untyped_error_in_catch.html
untyped_error_in_catch --> Ennek nem tudom h pontosan milyen hatranya van, ha nincs bekapcsolva

https://realm.github.io/SwiftLint/unowned_variable_capture.html
unowned_variable_capture --> Szerintem nincs baj az unowned hasznalattal. Igazabol ha ugy erezzuk hogy valami unowned-kent is mukodhet, de megis crash-sel akkor ott valami bug van amit weak-kel nem vettunk volna eszre. Szoval sztem jo a unowned. A masik opcio, hogy bizonyos weak-ekhez teszunk logot... csak azt meg konnyu elfelejteni.

https://realm.github.io/SwiftLint/vertical_whitespace_between_cases.html
vertical_whitespace_between_cases --> sztem folosleges kisebb switch-eknel, nagyot meg nem is kene irni...

## Did opted in

https://realm.github.io/SwiftLint/number_separator.html --> Ez sztem javit az olvashatosagon

https://realm.github.io/SwiftLint/override_in_extension.html --> Volt mar olyan h nem ertettem miert nem mukodik ak od, aztan volt valami buziskodas az extensionben overrideolt dolgokkal. 

https://realm.github.io/SwiftLint/type_contents_order.html
type_contents_order --> Nekem ez tetszik, mert alapvetoen hasonlo modon szoktam rendezni a dolgokat, de lehet h lintelni mar too much.

https://realm.github.io/SwiftLint/unused_import.html
unused_import --> Ennek van olyan configuracioja is hogy: "require_explicit_imports", azt betegyuk, csak hogy jobban atlassuk hogy konkretan mik a fuggosegek?