### PR TITLE
[TECH] Use empty header comments

### DIFF
--- a/Nest.xcworkspace/xcshareddata/IDETemplateMacros.plist
+++ b/Nest.xcworkspace/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>FILEHEADER</key>
+	<string></string>
+</dict>
+</plist>


### PR DESCRIPTION
Xcode by default creates a header comment that includes the file's name, the target name, the user who created the file and the date of creation. All of which can be easily located via Git history.

Adding the template macro will unfortunately not get rid of the header comment completely, but it will generate a header comment that does not contain all the boilerplate. Removing the header comment should be part of out tooling (e.g. Swiftformat)

|Before|After|
|-|-|
|<img width="444" alt="Screen Shot 2022-05-22 at 5 46 38 PM" src="https://user-images.githubusercontent.com/1413987/169704126-d4cd66a3-273f-4cb6-ad5a-a52d4de95188.png">|<img width="415" alt="Screen Shot 2022-05-22 at 5 46 59 PM" src="https://user-images.githubusercontent.com/1413987/169704125-2acaadd3-9a57-49f3-83a2-834f1b640dba.png">|